### PR TITLE
change numeric type

### DIFF
--- a/private/lbfgs.c
+++ b/private/lbfgs.c
@@ -76,7 +76,7 @@ void LBFGS_MATVEC_TWOLOOP(int n, int mem, double * dir_n, double * s_n_m, double
 
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
-    int n, mem, curridx, currmem, dir_dims[2];
+    size_t n, mem, curridx, currmem, dir_dims[2];
     double * dir, * s, * y, * ys, H, * g, * alpha;
 
     if (nrhs != 7) {


### PR DESCRIPTION
mxCreateNumericArray expects const size_t *, which is an unsigned numeric type and need to explicitly cast dimensions